### PR TITLE
Fix hifi block sorter REAL_DTYPE NameError

### DIFF
--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -34,7 +34,8 @@ from vhsdecode.hifi.utils import (
     PostProcessorSharedMemory,
     NumbaAudioArray,
     PeakGain,
-    BLOCK_DTYPE
+    BLOCK_DTYPE,
+    REAL_DTYPE,
 )
 
 import argparse


### PR DESCRIPTION
## Summary
- restore `REAL_DTYPE` import in `vhsdecode/hifi/main.py`
- fix worker crash in `PostProcessor.block_sorter_worker` when allocating `np.empty(..., dtype=REAL_DTYPE)`

## Validation
- import/runtime smoke checks in py3.14 env
- bounded and full decode tests completed without `REAL_DTYPE` NameError

Co-Authored-By: Oz <oz-agent@warp.dev>
