### PR TITLE
Update MacOS build pipelines for future compatibility

### DIFF
--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -6,12 +6,15 @@ on:
 
 jobs:
   build-decode:
+    timeout-minutes: 90
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-15-intel]
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
             python: "3.12"
           - os: macos-15-intel
@@ -33,12 +36,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
       - name: Generate version metadata
         shell: bash
         run: |
           set -euxo pipefail
           VERSION="$(python3 scripts/generate_version.py)"
-          SAFE_VERSION="${VERSION//:/-}"
+          SAFE_VERSION="$(printf '%s' "${VERSION}" | tr ':/ ' '---')"
           printf '%s\n' "${VERSION}" > lddecode/version
           echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
           echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
@@ -72,7 +79,7 @@ jobs:
           fi
 
           python3 -m pip install -r ./requirements.txt
-          python3 -m pip install pyinstaller
+          python3 -m pip install "pyinstaller>=6.20"
           python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"
 
       - name: Build binary
@@ -98,6 +105,7 @@ jobs:
           [[ "${VERSION_OUTPUT}" != "unknown" ]]
           "${APP_BIN}" ld --version
           "${APP_BIN}" vhs --help >/dev/null
+          "${APP_BIN}" hifi --help >/dev/null
           "${APP_BIN}" decode-launcher --help >/dev/null
 
       - name: Build DMG file

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -2,6 +2,7 @@ name: "Build macOS tools"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 env:
   FLALDF_FILE: "FlaLDF-v0.1-2-macos-x64.tar.gz"
@@ -9,12 +10,17 @@ env:
 
 jobs:
   build-tbc-tools:
+    timeout-minutes: 90
+    permissions:
+      contents: write
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-15-intel]
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
           - os: macos-15-intel
             arch: x86_64
@@ -27,6 +33,14 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Generate version metadata
+        shell: bash
+        run: |
+          set -euxo pipefail
+          VERSION="$(python3 scripts/generate_version.py)"
+          SAFE_VERSION="$(printf '%s' "${VERSION}" | tr ':/ ' '---')"
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Install dependencies
         run: brew install create-dmg cmake pkg-config qt qwt ffmpeg fftw
@@ -73,25 +87,50 @@ jobs:
           BREW_PREFIX="$(brew --prefix)"
           QT_PREFIX="$(brew --prefix qt)"
           "$QT_PREFIX/bin/macdeployqt" dist/tbc-tools.app -libpath="$BREW_PREFIX/lib"
+      - name: Smoke test bundled tools
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/tbc-tools.app/Contents/MacOS/ld-analyse"
+          test -x "${APP_BIN}"
+          BIN_ARCHS="$(lipo -archs "${APP_BIN}")"
+          echo "Detected architectures: ${BIN_ARCHS}"
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            [[ "${BIN_ARCHS}" == *"x86_64"* ]]
+          else
+            [[ "${BIN_ARCHS}" == *"arm64"* ]]
+          fi
+          "${APP_BIN}" --help >/dev/null
 
       - name: Build DMG file
-        run: >-
-          create-dmg
-          --volname "tbc-tools"
-          --volicon "assets/icons/tbc-tools.icns"
-          --window-pos 200 128
-          --window-size 600 300
-          --icon-size 100
-          --icon "tbc-tools.app" 172 120
-          --app-drop-link 425 128
-          --skip-jenkins
-          --hide-extension "tbc-tools.app"
-          "tbc-tools.dmg"
-          "dist/tbc-tools.app"
+        shell: bash
+        run: |
+          set -euxo pipefail
+          DMG_NAME="tbc-tools-${SAFE_VERSION}-${{ matrix.arch }}-macos.dmg"
+          echo "DMG_NAME=${DMG_NAME}" >> "${GITHUB_ENV}"
+          create-dmg \
+            --volname "tbc-tools" \
+            --volicon "assets/icons/tbc-tools.icns" \
+            --window-pos 200 128 \
+            --window-size 600 300 \
+            --icon-size 100 \
+            --icon "tbc-tools.app" 172 120 \
+            --app-drop-link 425 128 \
+            --skip-jenkins \
+            --hide-extension "tbc-tools.app" \
+            "${DMG_NAME}" \
+            "dist/tbc-tools.app"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
           name: tbc-tools_macos_${{ matrix.arch }}
-          path: tbc-tools.dmg
+          path: ${{ env.DMG_NAME }}
           if-no-files-found: error
+      - name: Upload DMG to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.DMG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -9,23 +9,27 @@ from shutil import move
 # Release/performance safety: never default macOS release artifacts to a
 # debug Rust profile when invoked locally outside CI.
 os.environ.setdefault("SETUPTOOLS_RUST_CARGO_PROFILE", "release")
+def _generate_build_version() -> str:
+    version_script = Path("scripts/generate_version.py")
+    if not version_script.is_file():
+        return ""
+    try:
+        return subprocess.check_output([sys.executable, str(version_script)], text=True).strip()
+    except Exception:
+        return ""
+
 
 def _ensure_lddecode_version_file() -> None:
     version_path = Path("lddecode/version")
-    if version_path.is_file() and version_path.read_text(encoding="utf-8").strip():
-        return
+    current_version = ""
+    if version_path.is_file():
+        current_version = version_path.read_text(encoding="utf-8").strip()
 
-    version = "unknown"
-    version_script = Path("scripts/generate_version.py")
-    if version_script.is_file():
-        try:
-            version = (
-                subprocess.check_output([sys.executable, str(version_script)], text=True)
-                .strip()
-                or "unknown"
-            )
-        except Exception:
-            version = "unknown"
+    generated_version = _generate_build_version()
+    version = generated_version or current_version or "unknown"
+    if current_version == version:
+        print(f"Using {version_path} = {version}")
+        return
 
     version_path.parent.mkdir(parents=True, exist_ok=True)
     version_path.write_text(f"{version}\n", encoding="utf-8")
@@ -72,14 +76,22 @@ PyInstaller.__main__.run(
         "assets/icons/vhs-decode.icns",
         "--add-data",
         "lddecode/version:lddecode",
-        "--onefile",
+        # onefile + .app is deprecated on macOS in newer PyInstaller releases.
+        "--onedir",
         "--windowed",
         "--name",
         "vhs-decode",
     ]
 )
-
-move(r"dist/vhs-decode.app/Contents/MacOS/vhs-decode", r"dist/vhs-decode.app/Contents/MacOS/decode")
+macos_dir = Path("dist/vhs-decode.app/Contents/MacOS")
+source_binary = macos_dir / "vhs-decode"
+target_binary = macos_dir / "decode"
+if source_binary.exists():
+    if target_binary.exists():
+        target_binary.unlink()
+    move(str(source_binary), str(target_binary))
+elif not target_binary.exists():
+    raise FileNotFoundError(f"Expected bundled binary at {source_binary} or {target_binary}")
 
 with Path("dist/vhs-decode.app/Contents/Info.plist").open(mode="rb+") as file:
     plist = plistlib.load(file)


### PR DESCRIPTION
## Summary

- migrate macOS decode packaging to PyInstaller onedir mode
- harden version metadata generation for deterministic bundle versions
- pin macOS runner families and strengthen decode smoke tests
- harden macOS tools workflow with reusable trigger, smoke checks, versioned DMGs, and tag release upload